### PR TITLE
docker build and workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,59 @@
+name: build
+
+on:
+  push:
+    branches:
+      - 'master'
+    tags:
+      - 'v*'
+  pull_request:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          submodules: recursive
+
+      - name: Set up Go
+        uses: actions/setup-go@v3.4.0
+        with:
+          go-version: 1.18
+
+      - name: Cache Go modules
+        uses: actions/cache@v3
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image (master)
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,27 @@
+name: test
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+        submodules: recursive
+
+    - name: Install Go
+      uses: actions/setup-go@v3
+      with:
+        go-version: 1.18.x
+
+    - name: Test
+      run: |
+        go test ./... -coverprofile=profile.cov
+
+    - uses: shogo82148/actions-goveralls@v1.6.0
+      with:
+        path-to-profile: profile.cov

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM golang:1.18.9 as builder
+WORKDIR /app
+COPY . .
+RUN go test ./... &&\
+    CGO_ENABLED=0 go build .
+
+FROM scratch
+COPY --from=builder /app/hydra-dragonfire /bin/hydra-dragonfire
+ENTRYPOINT ["/bin/hydra-dragonfire"]


### PR DESCRIPTION
this PR adds two workflows:
* one executes the go tests on `push` and `pull_request`
* the other builds a docker image to `ghcr.io/dragonfireclient/hydra-dragonfire`

Images are tagged with `v*` and `latest` (the v* image gets pushed if you set the tag on the repo, `v1.0` for example)

Background: i'd like to use this project for automated mod-testing, it looks mature enough and is scriptable :)

Usage example:
```bash
docker run --rm -it ghcr.io/dragonfireclient/hydra-dragonfire:latest my-script.lua 127.0.0.1:30000 test pass
```